### PR TITLE
Dockerize (poorly)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:2.7
+RUN wget http://nppes.viva-it.com/NPPES_Data_Dissemination_April_2015.zip
+RUN apt-get update && apt-get install unzip
+RUN unzip NPPES_Data_Dissemination_April_2015.zip && \
+    rm NPPES_Data_Dissemination_April_2015.zip && \
+    mkdir /data && \
+    mv npidata_20050523-20150412.csv /data
+
+ADD . /code
+WORKDIR /code/
+RUN pip install -r requirements.txt
+
+WORKDIR /code/nppes_fhir_demo

--- a/README.md
+++ b/README.md
@@ -18,3 +18,17 @@ Very brief instructions:
 
 More details later...
   
+
+## Dockerized version
+
+### Requirements
+
+ * Install docker (https://docs.docker.com/installation/)
+ * Install docker-compose (https://docs.docker.com/compose/install/)
+
+### Setup
+
+ * Launch the stack: `docker-compose up`
+ * Load sample data: `docker-compose run web python /code/nppes_fhir_demo/load_nppes_bulk.py`
+ * Try it: browse to http://host/nppes_fhir
+ * View logs `docker-compose logs`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+web:
+  build: .
+  command: python /code/nppes_fhir_demo/serve_nppes.py
+  ports:
+   - "5000:5000"
+  volumes:
+   - .:/code
+  links:
+   - esdb
+esdb:
+  image: elasticsearch
+  ports:
+   - "9200:9200"
+   - "9300:9300"

--- a/nppes_fhir_demo/load_nppes_bulk.py
+++ b/nppes_fhir_demo/load_nppes_bulk.py
@@ -5,7 +5,7 @@ from elasticsearch import helpers
 import json
 import time
 
-nppes_file = "../NPPES_data/npidata_20050523-20150308.csv" #download this 5GB file from CMS!
+nppes_file = "/data/npidata_20050523-20150412.csv" #download this 5GB file from CMS!
 nucc_file  = "../NPPES_data/nucc_taxonomy_150.csv"
 
 #this is the reference data used to specificy provider's specialties
@@ -95,8 +95,14 @@ def iter_nppes_data(nppes_file, nucc_dict, convert_to_json):
 
 count = 0
 nucc_dict = load_taxonomy(nucc_file)
+
+import os
+es_server = os.environ['ESDB_PORT_9200_TCP_ADDR'] or '127.0.0.1'
+es_port = os.environ['ESDB_PORT_9200_TCP_PORT'] or '9200'
+
+
 es = Elasticsearch([
-	'127.0.0.1:9200'  #point this to your elasticsearch service endpoint
+	'%s:%s'%(es_server, es_port)  #point this to your elasticsearch service endpoint
 	]) 
 
 start = time.time()

--- a/nppes_fhir_demo/serve_nppes.py
+++ b/nppes_fhir_demo/serve_nppes.py
@@ -173,9 +173,14 @@ def convert_to_Practitioner(es_provider_doc):
 
 #main program here
 
+import os
+es_server = os.environ['ESDB_PORT_9200_TCP_ADDR'] or '127.0.0.1'
+es_port = os.environ['ESDB_PORT_9200_TCP_PORT'] or '9200'
+
 try:
-	#connect to ElasticSearch, use all defaults
-	es = elasticsearch.Elasticsearch()
+	es = elasticsearch.Elasticsearch([
+	'%s:%s'%(es_server, es_port)  #point this to your elasticsearch service endpoint
+	]) 
 	print "connected to ES"
 except:
 	print "FAILED to connect to ES "
@@ -184,4 +189,4 @@ except:
 #if called locally (without gunicorn) then run on localhost port 5000 for debugging
 #otherwise, gunicorn will invoke the "app" entrypoint for WSGI conversation
 if __name__ == '__main__':
-	app.run(host="127.0.0.1", port=5000, debug=True)
+	app.run(host="0.0.0.0", port=5000, debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask==0.10.1
+elasticsearch>=1.0.0,<2.0.0


### PR DESCRIPTION
Make the requirements/configuration/environment explicit with a docker config that grabs elastic search + the NPI download, and launches the stack.
